### PR TITLE
fix: contract for give up or not able to complete the game scenarios

### DIFF
--- a/contracts_eth/config.js
+++ b/contracts_eth/config.js
@@ -6,9 +6,9 @@ import ERC20_ABI_JSON from '../game/abi/abi_erc20.json' assert { type: 'json' };
 // Define your contract addresses
 const addresses = {
     gameItems: '0x5b2970c664ed9f62b10c674e796a4e602491c0fb',   // sepolia Testnet Deployed Contract
-    stakingManager: '0x26226e2d34a8754e33afb2dd7c03fa21155fc222', // sepolia Testnet Deployed Contract
-    tradeManager: '0x79475AD66448E206F77467A8d0F0F0b23337eA31', // <-- FIX THIS ADDRESS
-    runeCoin: '0x0000000000000000000000000000000000697ded' // <-- ADD YOUR TOKEN ADDRESS
+    stakingManager: '0xc5995ff4a25f31e613b9e840e7be9be4c95021b0', // sepolia Testnet Deployed Contract
+    tradeManager: '0x79475AD66448E206F77467A8d0F0F0b23337eA31', 
+    runeCoin: '0x0000000000000000000000000000000000697ded' 
 };
 
 // Export the ABIs and addresses

--- a/contracts_eth/src/stakingManager.sol
+++ b/contracts_eth/src/stakingManager.sol
@@ -105,6 +105,24 @@ contract StakingManager is Ownable, ReentrancyGuard {
     }
 
     /**
+     * @dev Allows a player to forfeit their active single-player stake.
+     * This is used when a player gives up or fails to meet the time challenge.
+     * The staked amount is kept by the contract.
+     */
+    function forfeitStake() external nonReentrant {
+        SinglePlayerStake storage stake = singlePlayerStakes[msg.sender];
+        require(stake.isActive, "No active stake to forfeit.");
+
+        uint256 amountToForfeit = stake.amount;
+
+        // Deactivate stake
+        stake.isActive = false;
+
+        // The forfeited amount stays in the contract balance for owner withdrawal
+        emit StakeForfeited(msg.sender, amountToForfeit);
+    }
+
+    /**
      * @dev Allows a player to deposit funds for in-game actions, like paying a penalty for a wrong guess.
      */
     function depositFundsForHint() external payable {

--- a/game/abi/abi_staking.json
+++ b/game/abi/abi_staking.json
@@ -388,6 +388,13 @@
       ],
       "stateMutability": "view",
       "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "forfeitStake",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     }
   ]
 }

--- a/game/scenes/UIScene.js
+++ b/game/scenes/UIScene.js
@@ -62,7 +62,7 @@ export class UIScene extends Phaser.Scene {
 
   createLocationButton() {
     const button = this.add
-      .text(150, this.cameras.main.height - 80, "Choose Location", {
+      .text(170, this.cameras.main.height - 80, "Choose Location", {
         fontFamily: "Arial",
         fontSize: "24px",
         color: "#A9A9A9",
@@ -164,8 +164,21 @@ export class UIScene extends Phaser.Scene {
 
     button.on("pointerdown", () => {
       button.setText("Hold...");
-      giveUpTimer = this.time.delayedCall(3000, () => {
-        window.location.reload();
+      giveUpTimer = this.time.delayedCall(1500, () => {
+        this.scene.stop("HomeScene");
+        this.scene.stop("UIScene");
+        this.scene.start("EndScene", {
+          score: 0,
+          time: this.formatTime(this.elapsedSeconds),
+          guesses: this.homeScene.guessCount,
+          nfts: this.homeScene.nftCount,
+          account: this.account,
+          story: "You have given up on the quest.",
+          isCorrect: false, // This triggers the failure/forfeit scenario
+          isStaking: this.homeScene.isStaking,
+          elapsedTime: this.elapsedSeconds,
+          timeLimit: this.homeScene.timeLimit,
+        });
       });
     });
 
@@ -215,7 +228,6 @@ export class UIScene extends Phaser.Scene {
   showLocationChoices() {
     if (this._locationOverlay) return;
 
-    // Lock location choices if a penalty is due in a staking game.
     if (this.homeScene.isStaking && this.homeScene.guessMade) {
       return;
     }


### PR DESCRIPTION
Introduces a forfeitStake function to the stakingManager contract and exposes it in the ABI. The game now detects and forfeits abandoned stakes on app load and when a player fails or gives up during a staking game. UI updates and logic changes in EndScene and UIScene ensure forfeiture is handled and communicated to the player.