### PR TITLE
refactor: player movement tracking logic

### DIFF
--- a/game/scenes/HomeScene.js
+++ b/game/scenes/HomeScene.js
@@ -999,27 +999,7 @@ export class HomeScene extends Phaser.Scene {
     
     // Add stuck detection
     const currentPos = { x: this.player.x, y: this.player.y };
-    if (this.lastPlayerPos) {
-      const timeSinceLastMove = this.time.now - (this.lastMoveTime || 0);
-      const distanceMoved = Phaser.Math.Distance.Between(
-        currentPos.x, currentPos.y,
-        this.lastPlayerPos.x, this.lastPlayerPos.y
-      );
-      
-      // If player hasn't moved for 2 seconds while trying to move
-      if (timeSinceLastMove > 2000 && distanceMoved < 5 && 
-          (this.cursors.left.isDown || this.cursors.right.isDown || 
-           this.cursors.up.isDown || this.cursors.down.isDown)) {
-        console.log("Player appears stuck, resetting position");
-        this.player.setPosition(this.initialPlayerPos.x, this.initialPlayerPos.y);
-      }
-    }
-    
-    // Update position tracking
-    this.lastPlayerPos = currentPos;
-    if (velocityX !== 0 || velocityY !== 0) {
-      this.lastMoveTime = this.time.now;
-    }
+
     
     if (this.activeMintZone) {
       const playerBounds = this.player.getBounds();
@@ -1128,12 +1108,17 @@ export class HomeScene extends Phaser.Scene {
     if (velocityX !== 0 || velocityY !== 0) {
       if (this.isWalkableAt(nextX, nextY)) {
         this.player.setVelocity(velocityX, velocityY);
+        // record actual movement time only when we set a non-zero velocity
+        this.lastMoveTime = this.time.now;
       } else {
         this.player.setVelocity(0, 0);
       }
     } else {
       this.player.setVelocity(0, 0);
     }
+
+    // update lastPlayerPos for the next frame (now that velocity vars exist)
+    this.lastPlayerPos = currentPos;
 
     this.villagers.getChildren().forEach((villager) => {
       if (villager.lockIcon) {


### PR DESCRIPTION
This pull request refactors the movement tracking logic in the `HomeScene` class to simplify player position updates and remove stuck detection. The main change is the removal of the code that automatically resets the player's position if they appear stuck, and the adjustment of how movement timing and position tracking are handled.

Movement tracking and stuck detection:

* Removed the stuck detection logic that reset the player's position if they hadn't moved for 2 seconds while attempting to move. (`game/scenes/HomeScene.js`)
* Refactored the update of `lastMoveTime` to only occur when the player actually moves, and moved the update of `lastPlayerPos` to the end of the movement logic for more accurate tracking. (`game/scenes/HomeScene.js`)Moved player position and movement time tracking to after velocity is set, ensuring accurate updates. Removed redundant stuck detection logic from the earlier position in the update loop.